### PR TITLE
Tolerate empty lines in artifact-properties

### DIFF
--- a/src/main/java/io/spring/github/actions/artifactorydeploy/artifactory/StringToArtifactPropertiesConverter.java
+++ b/src/main/java/io/spring/github/actions/artifactorydeploy/artifactory/StringToArtifactPropertiesConverter.java
@@ -36,6 +36,7 @@ import org.springframework.util.StringUtils;
  * {@link String}.
  *
  * @author Andy Wilkinson
+ * @author Artem Bilan
  */
 class StringToArtifactPropertiesConverter implements Converter<String, List<ArtifactProperties>> {
 
@@ -46,11 +47,11 @@ class StringToArtifactPropertiesConverter implements Converter<String, List<Arti
 	}
 
 	private ArtifactProperties toArtifactProperties(String line) {
-		if (!StringUtils.hasLength(line)) {
+		if (!StringUtils.hasText(line)) {
 			return null;
 		}
 		String[] components = line.split(":");
-		Assert.state(components != null && components.length == 3,
+		Assert.state(components.length == 3,
 				"Artifact properties must be configured in the form <includes>:<excludes>:<properties>");
 		return new ArtifactProperties(commaSeparatedList(components[0]), commaSeparatedList(components[1]),
 				commaSeparatedKeyValues(components[2]));
@@ -68,7 +69,7 @@ class StringToArtifactPropertiesConverter implements Converter<String, List<Arti
 		for (String pair : input.split(",")) {
 			int equalsIndex = pair.indexOf('=');
 			String key = pair.substring(0, equalsIndex);
-			String value = pair.substring(equalsIndex + 1, pair.length());
+			String value = pair.substring(equalsIndex + 1);
 			properties.put(key, value);
 		}
 		return properties;

--- a/src/test/java/io/spring/github/actions/artifactorydeploy/artifactory/StringToArtifactPropertiesConverterTests.java
+++ b/src/test/java/io/spring/github/actions/artifactorydeploy/artifactory/StringToArtifactPropertiesConverterTests.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link StringToArtifactPropertiesConverter}.
  *
  * @author Andy Wilkinson
+ * @author Artem Bilan
  */
 class StringToArtifactPropertiesConverterTests {
 
@@ -75,7 +76,7 @@ class StringToArtifactPropertiesConverterTests {
 	@Test
 	void convertWithMultipleLinesProducesMultipleArtifactProperties() {
 		List<ArtifactProperties> artifactProperties = this.converter
-			.convert("one,two:three:a=alpha,b=bravo%nfour:five:c=charlie%nsix:seven:d=delta".formatted());
+			.convert("one,two:three:a=alpha,b=bravo%n    %nfour:five:c=charlie%nsix:seven:d=delta".formatted());
 		assertThat(artifactProperties).hasSize(3).first().satisfies((properties) -> {
 			assertThat(properties.include()).containsExactly("one", "two");
 			assertThat(properties.exclude()).containsExactly("three");


### PR DESCRIPTION
The problem with action configuration in YAML:
```
        artifact-properties: |
          /**/*.zip::zip.name=${{ github.event.repository.name }},zip.deployed=false
          /**/*docs.zip::zip.type=docs
          /**/*dist.zip::zip.type=dist

```
It visually not obvious that there are some empty lines in the end. Plus end-user may decide to separate those entries with empty lines as well.

* Fix `StringToArtifactPropertiesConverter` to use `StringUtils.hasText()`. The `hasLength()` does count whitespaces as content

* Some other suggested by IDEA simple refactoring for the `StringToArtifactPropertiesConverter`:
   - `String.split()` never returns null
   - `String.substring()` without second argument yields to `length()` internally